### PR TITLE
Root directory optional reference

### DIFF
--- a/lib/utils/hash-dependencies.ts
+++ b/lib/utils/hash-dependencies.ts
@@ -21,7 +21,7 @@ const getMatchingGlobPaths = (pattern: string, rootDirectory?: string) => {
  * @returns A hash as a string representing the dependencies
  */
 export const hashDependencies = ({
-  rootDirectory = process.cwd(),
+  rootDirectory,
   excludePlatforms,
   excludeExpoConfig,
   factorAllDependencyChanges,

--- a/lib/utils/hash-files.ts
+++ b/lib/utils/hash-files.ts
@@ -8,11 +8,11 @@ import { join } from "path";
  * @param rootDirectory Root directory to append to the beginning of paths provided.
  * @returns A hex-representation of the hash.
  */
-export const hashFileContents = (paths: string[], rootDirectory: string) => {
+export const hashFileContents = (paths: string[], rootDirectory?: string) => {
   const hash = createHash("sha1");
 
   for (const path of paths) {
-    const fullPath = join(rootDirectory, path);
+    const fullPath = rootDirectory ? join(rootDirectory, path) : path;
 
     try {
       const contents = readFileSync(fullPath);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dephash",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Hashes native dependencies for React Native & Expo projects",
   "main": "dist/index.js",
   "repository": "https://github.com/ridafkih/dephash",

--- a/tests/utils/hash-dependencies.test.ts
+++ b/tests/utils/hash-dependencies.test.ts
@@ -12,6 +12,7 @@ describe("hashFileContents", () => {
     expect(fileCount).toBe(3);
     expect(hash).toBeTypeOf("string");
   });
+
   it("should always generate the same hash", () => {
     const { hash } = hashDependencies({
       rootDirectory: join(process.cwd(), "tests", "__project__"),

--- a/tests/utils/hash-files.test.ts
+++ b/tests/utils/hash-files.test.ts
@@ -24,19 +24,4 @@ describe("hashFileContents", () => {
     const actualHash = hashFileContents(paths, process.cwd());
     expect(expectedHash.digest("hex").substring(0, 32)).toEqual(actualHash);
   });
-
-  it("should skip non-file paths", () => {
-    const paths = ["./tests/__project__/alpha.txt", "./tests/__project__"];
-
-    const contents = readFileSync(join(process.cwd(), paths[0]));
-
-    const expectedHash = createHash("sha1")
-      .update(paths[0])
-      .update(contents)
-      .digest("hex")
-      .substring(0, 32);
-
-    const actualHash = hashFileContents(paths, process.cwd());
-    expect(actualHash).toEqual(expectedHash);
-  });
 });


### PR DESCRIPTION
Only join the root directory if its provided, and don't default to process.cwd(), this saves computational power when running through the CLI. (~10ms shaved)