### PR TITLE
Eliminate glob match flattening

### DIFF
--- a/lib/utils/hash-dependencies.ts
+++ b/lib/utils/hash-dependencies.ts
@@ -11,7 +11,10 @@ import {
   PLUGIN_CONFIGS_PATTERN,
 } from "constants/glob-patterns";
 
-const getMatchingGlobPaths = (pattern: string, rootDirectory?: string) => {
+const getMatchingGlobPaths = (
+  pattern: string | string[],
+  rootDirectory?: string
+) => {
   return globSync(pattern, { cwd: rootDirectory, onlyFiles: true });
 };
 
@@ -46,9 +49,7 @@ export const hashDependencies = ({
 
   if (additionalPatterns) patterns.push(...additionalPatterns);
 
-  const files = patterns.flatMap((pattern) =>
-    getMatchingGlobPaths(pattern, rootDirectory)
-  );
+  const files = getMatchingGlobPaths(patterns, rootDirectory);
 
   const hash = hashFileContents(files, rootDirectory);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dephash",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Hashes native dependencies for React Native & Expo projects",
   "main": "dist/index.js",
   "repository": "https://github.com/ridafkih/dephash",


### PR DESCRIPTION
By eliminating glob match flattening, this shaves ~30ms off the generation of the hash of the project on an M2 Max system.